### PR TITLE
Missing a fallback

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -378,6 +378,14 @@ function template_process_islandora_newspaper_page(array &$variables) {
       $variables['content'] = NULL;
     }
   }
+  // Fallback to image.
+  elseif (isset($object['JPG']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['JPG'])) {
+    $params = array(
+      'title' => $object->label,
+      'path' => url("islandora/object/{$object->id}/datastream/JPG/view"),
+    );
+    $variables['content'] = theme('image', $params);
+  }
   else {
     $variables['content'] = NULL;
   }


### PR DESCRIPTION
To fix the discussion in issue [#121](https://github.com/Islandora/islandora_solution_pack_newspaper/pull/121).

We only fallback if the viewer fails to load, not if we haven't selected a viewer.